### PR TITLE
Update Circle CI config to upload packages sequentially

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,6 @@ workflows:
                 - master
                 - /v[0-9]+\.[0-9]+/
                 - feature/circleci
-                - update_circleci_config
   build_test_nightly:
     jobs:
         - build_and_test_python27


### PR DESCRIPTION
This pull request updates Circle CI config deploy job to deploy packages to packagecloud sequentially instead of in parallel.

I'm personally not too opinionated about it, as long as it's consistent. Especially in this scenario where packages are quite small.

Related to https://github.com/StackStorm/st2-enterprise-rbac-backend/pull/1#discussion_r270156447