### PR TITLE
Suppress pip warnings on uninstall on upgrade

### DIFF
--- a/debian/postrm
+++ b/debian/postrm
@@ -20,7 +20,7 @@ set -e
 
 uninstall_package() {
   PIP=/opt/stackstorm/st2/bin/pip
-  echo y | ${PIP} uninstall st2-enterprise-rbac-backend 1>/dev/null || :
+  ${PIP} uninstall -y --quiet st2-enterprise-rbac-backend 1>/dev/null || :
 }
 
 disable_rbac() {

--- a/rpm/postun_script.spec
+++ b/rpm/postun_script.spec
@@ -1,6 +1,6 @@
 uninstall_package() {
   PIP=/opt/stackstorm/st2/bin/pip
-  echo y | ${PIP} uninstall st2-enterprise-rbac-backend 1>/dev/null || :
+  ${PIP} uninstall -y --quiet st2-enterprise-rbac-backend 1>/dev/null || :
 }
 
 disable_rbac() {


### PR DESCRIPTION
This pull request passes ``--quiet`` flag to ``pip uninstall`` command so it suppresses non fatal warnings on package removal on upgrade (we already pass this flag to ``pip install`` during package installation).

I also updated the command line to use ``-y`` flag so pip runs in command line and non-interactive mode (should be more robust than piping ``y`` to pip stdin).

Resolves https://github.com/StackStorm/st2-enterprise-auth-backend-ldap/issues/56.