### PR TITLE
Only enable RBAC on install and not on upgrade

### DIFF
--- a/rpm/postinst_script.spec
+++ b/rpm/postinst_script.spec
@@ -18,7 +18,8 @@ configure_rbac() {
 install_pacakge
 
 # NOTE: We only enable RBAC on initial installation. On upgrade we leave st2.conf alone.
-if [ "$1" -ge 1 ]; then
+# https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_syntax
+if [ "$1" -eq 1 ]; then
   enable_rbac
 fi
 


### PR DESCRIPTION
It looks like the check was wrong (although I wonder how that came to be since the change was tested under various scenarios).

Related to https://github.com/StackStorm/st2-packages/pull/611.