### PR TITLE
Always re-enable RBAC in st2.conf on upgrade

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -43,10 +43,17 @@ case "$1" in
       install_package
 
       # NOTE: We only enable RBAC on initial installation. On upgrade we leave st2.conf alone.
-      [ "${upgrading}" = 1 ] || enable_rbac
-
+      #[ "${upgrading}" = 1 ] || enable_rbac
+      #
       # Clean up a file which signals a package upgrade
       rm -f ${ST2_RBAC_UPGRADESTAMP}
+
+      # NOTE: Due to the bug in v3.0.0 where we incorrectly disable RBAC on upgrade we need to always
+      # enable RBAC - also on upgrade and not just on install otherwise users upgrading from v3.0.0
+      # would end up with RBAC disabled on upgrade.
+      # See https://github.com/StackStorm/st2-enterprise-rbac-backend/pull/13#issuecomment-495121941
+      # We can remove this and do it only on uprade in a future release- e.g. v3.2.0
+      enable_rbac
 
       # We still set rbac.backend to enterprise to correctly handle upgrades from pre v3.0.0
       # where this option was added. If we don't do that, users who had previously configured

--- a/rpm/postinst_script.spec
+++ b/rpm/postinst_script.spec
@@ -19,8 +19,15 @@ install_package
 
 # NOTE: We only enable RBAC on initial installation. On upgrade we leave st2.conf alone.
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_syntax
-if [ "$1" -eq 1 ]; then
-  enable_rbac
-fi
+#
+#if [ "$1" -eq 1 ]; then
+#  enable_rbac
+#fi
 
+# NOTE: Due to the bug in v3.0.0 where we incorrectly disable RBAC on upgrade we need to always
+# enable RBAC - also on upgrade and not just on install otherwise users upgrading from v3.0.0
+# would end up with RBAC disabled on upgrade.
+# See https://github.com/StackStorm/st2-enterprise-rbac-backend/pull/13#issuecomment-495121941
+# We can remove this and do it only on uprade in a future release- e.g. v3.2.0
+enable_rbac
 configure_rbac


### PR DESCRIPTION
Due to the bug in v3.0.0 postrm / postun script where we incorrectly disabled RBAC on upgrade (and not just uninstall) we need to always re-enable RBAC in st2.conf on postinst on upgrade otherwise people upgrading from v3.0.0 would end up with RBAC disabled on upgrade.

This workaround is not ideal, but we don't have many good options.

In deb postinst we could at least detect if user is upgrading from 3.0.0 and only perform this workaround then (e.g. something liket this https://gist.github.com/Kami/18f145c4b22c0a6e09c55e50d2075289), but I couldn't find an robust way to do that for RPM packages.

We can probably remove this workaround in v3.2.0 or v3.3.0, we just need to document that in upgrade notes then.