### PR TITLE
Add include and exclude attributes test cases for executions API endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,9 @@ PKG_RELEASE ?= 1
 WHEELSDIR ?= opt/stackstorm/share/wheels
 VIRTUALENV_DIR ?= virtualenv
 ST2_REPO_PATH ?= /tmp/st2
-#ST2_REPO_URL ?= git@github.com:StackStorm/st2.git
-ST2_REPO_URL ?= git@github.com:jdmeyer3/st2.git
+ST2_REPO_URL ?= git@github.com:StackStorm/st2.git
 #ST2_REPO_URL ?= git@github.com:StackStorm/st2-private.git
-ST2_REPO_BRANCH ?= bug/enterprise_ldap_view_executions_error
-#ST2_REPO_BRANCH ?= master
+ST2_REPO_BRANCH ?= master
 
 ifneq (,$(wildcard /etc/debian_version))
 	DEBIAN := 1


### PR DESCRIPTION
This pull request adds tests for ``?include_attributes`` and ``?exclude_attributes`` query param filters for /v1/executions API endpoint when RBAC is enabled.

We already have those tests for all the list / get all API endpoints when RBAC is disabled, but we didn't have any when RBAC is enabled.

It turns out there is an edge case / bug which is fixed in https://github.com/StackStorm/st2/pull/4759.

While working on this, I uncovered another bug. When ``permission_isolation`` config option is enabled, ``context`` attribute is mandatory as well.

NOTE: This PR will fail until https://github.com/StackStorm/st2/pull/4759 is merged.