### PR TITLE
[RFC] "action_execute" should also grant "execution_view" on all the corresponding executions

### DIFF
--- a/st2rbac_enterprise_backend/resolvers.py
+++ b/st2rbac_enterprise_backend/resolvers.py
@@ -675,22 +675,24 @@ class ExecutionPermissionsResolver(PermissionsResolver):
         action_uid = action['uid']
         action_pack_uid = pack_db.get_uid()
 
-        # Note: "action_execute" also grants / implies "execution_re_run" and "execution_stop"
+        # NOTE: "action_execute" also grants / implies "execution_re_run" and "execution_stop"
         if permission_type == PermissionType.EXECUTION_VIEW:
-            action_permission_type = PermissionType.ACTION_VIEW
+            # NOTE: action_execute also grants action_view
+            action_permission_types = [PermissionType.ACTION_VIEW,
+                                       PermissionType.ACTION_EXECUTE]
         elif permission_type in [PermissionType.EXECUTION_RE_RUN,
                                  PermissionType.EXECUTION_STOP]:
-            action_permission_type = PermissionType.ACTION_EXECUTE
+            action_permission_types = [PermissionType.ACTION_EXECUTE]
         elif permission_type == PermissionType.EXECUTION_ALL:
-            action_permission_type = PermissionType.ACTION_ALL
+            action_permission_types = [PermissionType.ACTION_ALL]
         elif permission_type == PermissionType.EXECUTION_VIEWS_FILTERS_LIST:
-            action_permission_type = PermissionType.EXECUTION_VIEWS_FILTERS_LIST
+            action_permission_types = [PermissionType.EXECUTION_VIEWS_FILTERS_LIST]
         else:
             raise ValueError('Invalid permission type: %s' % (permission_type))
 
         # Check grants on the pack of the action to which execution belongs to
         resource_types = [ResourceType.PACK]
-        permission_types = [PermissionType.ACTION_ALL, action_permission_type]
+        permission_types = [PermissionType.ACTION_ALL] + action_permission_types
         permission_grants = rbac_service.get_all_permission_grants_for_user(user_db=user_db,
                                                                resource_uid=action_pack_uid,
                                                                resource_types=resource_types,
@@ -702,7 +704,7 @@ class ExecutionPermissionsResolver(PermissionsResolver):
 
         # Check grants on the action the execution belongs to
         resource_types = [ResourceType.ACTION]
-        permission_types = [PermissionType.ACTION_ALL, action_permission_type]
+        permission_types = [PermissionType.ACTION_ALL] + action_permission_types
         permission_grants = rbac_service.get_all_permission_grants_for_user(user_db=user_db,
                                                                resource_uid=action_uid,
                                                                resource_types=resource_types,

--- a/tests/unit/test_rbac_resolvers.py
+++ b/tests/unit/test_rbac_resolvers.py
@@ -221,6 +221,11 @@ class BasePermissionsResolverTestCase(CleanDbTestCase):
         pack_2_db = Pack.add_or_update(pack_2_db)
         self.resources['pack_2'] = pack_2_db
 
+        pack_3_db = PackDB(name='test_pack_3', ref='test_pack_3', description='',
+                           version='0.1.0', author='foo', email='test@example.com')
+        pack_3_db = Pack.add_or_update(pack_3_db)
+        self.resources['pack_3'] = pack_3_db
+
     def _insert_common_mock_roles(self):
         # Insert common mock roles
         admin_role_db = rbac_service.get_role_by_name(name=SystemRole.ADMIN)

--- a/tests/unit/test_rbac_resolvers_action.py
+++ b/tests/unit/test_rbac_resolvers_action.py
@@ -73,6 +73,14 @@ class ActionPermissionsResolverTestCase(BasePermissionsResolverTestCase):
         user_10_db = User.add_or_update(user_10_db)
         self.users['custom_role_action_list_grant'] = user_10_db
 
+        user_11_db = UserDB(name='custom_role_action_execute_action_4_grant')
+        user_11_db = User.add_or_update(user_11_db)
+        self.users['custom_role_action_execute_action_4_grant'] = user_11_db
+
+        user_12_db = UserDB(name='custom_role_action_execute_action_5_pack_grant')
+        user_12_db = User.add_or_update(user_12_db)
+        self.users['custom_role_action_execute_action_5_pack_grant'] = user_12_db
+
         # Create some mock resources on which permissions can be granted
         action_1_db = ActionDB(pack='test_pack_1', name='action1', entry_point='',
                                runner_type={'name': 'local-shell-cmd'})
@@ -88,6 +96,16 @@ class ActionPermissionsResolverTestCase(BasePermissionsResolverTestCase):
                                runner_type={'name': 'local-shell-cmd'})
         action_3_db = Action.add_or_update(action_3_db)
         self.resources['action_3'] = action_3_db
+
+        action_4_db = ActionDB(pack='test_pack_4', name='action4', entry_point='',
+                               runner_type={'name': 'local-shell-cmd'})
+        action_4_db = Action.add_or_update(action_4_db)
+        self.resources['action_4'] = action_4_db
+
+        action_5_db = ActionDB(pack='test_pack_3', name='action5', entry_point='',
+                               runner_type={'name': 'local-shell-cmd'})
+        action_5_db = Action.add_or_update(action_5_db)
+        self.resources['action_5'] = action_5_db
 
         # Create some mock roles with associated permission grants
         # Custom role 2 - one grant on parent pack
@@ -200,6 +218,28 @@ class ActionPermissionsResolverTestCase(BasePermissionsResolverTestCase):
         role_10_db = Role.add_or_update(role_10_db)
         self.roles['custom_role_action_list_grant'] = role_10_db
 
+        # Custom role - "action_execute" on action_4
+        grant_db = PermissionGrantDB(resource_uid=self.resources['action_4'].get_uid(),
+                                     resource_type=ResourceType.ACTION,
+                                     permission_types=[PermissionType.ACTION_EXECUTE])
+        grant_db = PermissionGrant.add_or_update(grant_db)
+        permission_grants = [str(grant_db.id)]
+        role_11_db = RoleDB(name='custom_role_action_execute_action_4_grant',
+                           permission_grants=permission_grants)
+        role_11_db = Role.add_or_update(role_11_db)
+        self.roles['custom_role_action_execute_action_4_grant'] = role_11_db
+
+        # Custom role - "action_execute" on action_5 parent pack
+        grant_db = PermissionGrantDB(resource_uid=self.resources['pack_3'].get_uid(),
+                                     resource_type=ResourceType.PACK,
+                                     permission_types=[PermissionType.ACTION_EXECUTE])
+        grant_db = PermissionGrant.add_or_update(grant_db)
+        permission_grants = [str(grant_db.id)]
+        role_12_db = RoleDB(name='custom_role_action_execute_action_5_pack_grant',
+                           permission_grants=permission_grants)
+        role_12_db = Role.add_or_update(role_12_db)
+        self.roles['custom_role_action_execute_action_5_pack_grant'] = role_12_db
+
         # Create some mock role assignments
         user_db = self.users['custom_role_action_pack_grant']
         role_assignment_db = UserRoleAssignmentDB(
@@ -258,6 +298,19 @@ class ActionPermissionsResolverTestCase(BasePermissionsResolverTestCase):
         user_db = self.users['custom_role_action_list_grant']
         role_assignment_db = UserRoleAssignmentDB(
             user=user_db.name, role=self.roles['custom_role_action_list_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
+        UserRoleAssignment.add_or_update(role_assignment_db)
+
+        user_db = self.users['custom_role_action_execute_action_4_grant']
+        role_assignment_db = UserRoleAssignmentDB(
+            user=user_db.name, role=self.roles['custom_role_action_execute_action_4_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
+        UserRoleAssignment.add_or_update(role_assignment_db)
+
+        user_db = self.users['custom_role_action_execute_action_5_pack_grant']
+        role_assignment_db = UserRoleAssignmentDB(
+            user=user_db.name,
+            role=self.roles['custom_role_action_execute_action_5_pack_grant'].name,
             source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
@@ -518,7 +571,30 @@ class ActionPermissionsResolverTestCase(BasePermissionsResolverTestCase):
             resource_db=resource_db,
             permission_type=PermissionType.ACTION_EXECUTE)
 
-        # "execute" also grants "view"
+        # Direct "action_execute" grant on action_4 which also grants action_view
+        user_db = self.users['custom_role_action_execute_action_4_grant']
+        resource_db = self.resources['action_4']
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
+            user_db=user_db,
+            resource_db=resource_db,
+            permission_type=PermissionType.ACTION_VIEW)
+
+        permission_types = [
+            PermissionType.ACTION_CREATE,
+            PermissionType.ACTION_MODIFY,
+            PermissionType.ACTION_DELETE
+        ]
+        self.assertUserDoesntHaveResourceDbPermissions(
+            resolver=resolver,
+            user_db=user_db,
+            resource_db=resource_db,
+            permission_types=permission_types)
+
+        # "action_execute" grant on action_5 parent pack which also grants "action_view" to
+        # all actions inside that pack
+        user_db = self.users['custom_role_action_execute_action_5_pack_grant']
+        resource_db = self.resources['action_5']
         self.assertUserHasResourceDbPermission(
             resolver=resolver,
             user_db=user_db,

--- a/tests/unit/test_rbac_resolvers_execution.py
+++ b/tests/unit/test_rbac_resolvers_execution.py
@@ -525,7 +525,6 @@ class ExecutionPermissionsResolverTestCase(BasePermissionsResolverTestCase):
             resource_db=resource_db,
             permission_type=PermissionType.EXECUTION_VIEW)
 
-
         # Custom role - "action_execute" on action_2 parent pack, user should be able to view all
         # the executions for actions which belong to that pack
         user_db = self.users['custom_role_action_execute_action_2_pack_grant']


### PR DESCRIPTION
Closes #23

This pull request updates RBAC resolvers code and updates it so now ``action_execute`` permission either on the action directly or on a pack, implicitly grants ``execution_view`` permission for all the executions which belong to that particular action (or to all the actions which belong to a particular pack).

This was implemented, because of the discussion in #23.

It's worth noting that this is **not** a bug fix.

This is a new functionality / change of behavior which has security implications (see my comment here https://github.com/extremenetworks/st2-enterprise-rbac-backend/issues/23#issuecomment-521204374).

---

I think that change is reasonable since we already have some other implicit grants in other places, but it could surprise users so it's important all the implications are documented.

With this change, if user A has ``action_execute`` permission on Action 1, that user will also be able to view all the executions for that action, even the ones which are triggered by other users if ``rbac.permission_isolation`` is not enabled (it's disabled by default).

I personally think that's a reasonable behavior (since it's already the case for ``execution_re_run`` and ``execution_stop``), but we should probably also enable ``rbac.permission_isolation`` by default at some point in the future.

What do others think?

## TODO

- [ ] Document this change of behavior in upgrade notes, add a note on user resource permission isolation
- [ ] Document this behavior in the RBAC docs