### PR TITLE
Fix package rename to clean up references to enterprise

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include bin/*
-include st2-enterprise-rbac-backend-default/cmd/*.py
+include st2-rbac-backend/cmd/*.py
 include dist_utils.py
 include requirements.txt
 include LICENSE

--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
-# StackStorm Enterprise RBAC Backend for StackStorm Enterprise Edition
-
-StackStorm RBAC backend for enterprise version which contains all the proprietary RBAC
-(permission resolving) business logic.
+# RBAC Backend for StackStorm
 
 NOTE: Due to the original code structure and the code originally living as part of the
 open source StackStorm/st2 repo, some of the utility RBAC code is still part of the open
@@ -20,7 +17,7 @@ NOTE: This happens automatically when using bwc installer script.
 ...
 [rbac]
 enable = True
-backend = enterprise
+backend = default
 ...
 3. Restart all the services - ``sudo st2ctl restart``
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # RBAC Backend for StackStorm
 
+The RBAC backend started as part of StackStorm core repo and then moved out into a separate
+repo for enterprise purposes. Some enterprise features such as RBAC has been made open
+sourced as part of the donation to Linux Foundation in 2019.
+
 NOTE: Due to the original code structure and the code originally living as part of the
 open source StackStorm/st2 repo, some of the utility RBAC code is still part of the open
 source repo (that code is of little use without the permission resolving classes which

--- a/debian/postinst
+++ b/debian/postinst
@@ -24,7 +24,7 @@ upgrading=0
 install_package() {
   PIP=/opt/stackstorm/st2/bin/pip
   WHEELSDIR=/opt/stackstorm/share/wheels
-  ${PIP} install --find-links ${WHEELSDIR} --no-index --quiet --upgrade st2-enterprise-rbac-backend
+  ${PIP} install --find-links ${WHEELSDIR} --no-index --quiet --upgrade st2-rbac-backend
 }
 
 enable_rbac() {
@@ -32,7 +32,7 @@ enable_rbac() {
 }
 
 configure_rbac() {
-  crudini --set ${ST2_CONFPATH} rbac backend 'enterprise'
+  crudini --set ${ST2_CONFPATH} rbac backend 'default'
 }
 
 # Choose first install or upgrade
@@ -51,7 +51,7 @@ case "$1" in
       # NOTE: Due to the bug in v3.0.0 where we incorrectly disable RBAC on upgrade we need to always
       # enable RBAC - also on upgrade and not just on install otherwise users upgrading from v3.0.0
       # would end up with RBAC disabled on upgrade.
-      # See https://github.com/StackStorm/st2-enterprise-rbac-backend/pull/13#issuecomment-495121941
+      # See https://github.com/StackStorm/st2-rbac-backend/pull/13#issuecomment-495121941
       # We can remove this and do it only on uprade in a future release- e.g. v3.2.0
       enable_rbac
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -55,8 +55,8 @@ case "$1" in
       # We can remove this and do it only on uprade in a future release- e.g. v3.2.0
       enable_rbac
 
-      # We still set rbac.backend to enterprise to correctly handle upgrades from pre v3.0.0
-      # where this option was added. If we don't do that, users who had previously configured
+      # We still set rbac.backend to "default" to correctly handle upgrades. Previously, this
+      # value was "enterprise". If we don't do that, users who had previously configured
       # RBAC, but don't set this config option could potentially end up with RBAC disabled.
       configure_rbac
     ;;

--- a/debian/postrm
+++ b/debian/postrm
@@ -20,7 +20,7 @@ set -e
 
 uninstall_package() {
   PIP=/opt/stackstorm/st2/bin/pip
-  ${PIP} uninstall -y --quiet st2-enterprise-rbac-backend 1>/dev/null || :
+  ${PIP} uninstall -y --quiet st2-rbac-backend 1>/dev/null || :
 }
 
 disable_rbac() {

--- a/rpm/postinst_script.spec
+++ b/rpm/postinst_script.spec
@@ -3,7 +3,7 @@ set -e
 install_package() {
   PIP=/opt/stackstorm/st2/bin/pip
   WHEELSDIR=/opt/stackstorm/share/wheels
-  ${PIP} install --find-links ${WHEELSDIR} --no-index --quiet --upgrade st2-enterprise-rbac-backend
+  ${PIP} install --find-links ${WHEELSDIR} --no-index --quiet --upgrade st2-rbac-backend
 }
 
 
@@ -12,7 +12,7 @@ enable_rbac() {
 }
 
 configure_rbac() {
-  crudini --set /etc/st2/st2.conf rbac backend 'enterprise'
+  crudini --set /etc/st2/st2.conf rbac backend 'default'
 }
 
 install_package
@@ -27,7 +27,7 @@ install_package
 # NOTE: Due to the bug in v3.0.0 where we incorrectly disable RBAC on upgrade we need to always
 # enable RBAC - also on upgrade and not just on install otherwise users upgrading from v3.0.0
 # would end up with RBAC disabled on upgrade.
-# See https://github.com/StackStorm/st2-enterprise-rbac-backend/pull/13#issuecomment-495121941
+# See https://github.com/StackStorm/st2-rbac-backend/pull/13#issuecomment-495121941
 # We can remove this and do it only on uprade in a future release- e.g. v3.2.0
 enable_rbac
 configure_rbac

--- a/rpm/posttrans_script.spec
+++ b/rpm/posttrans_script.spec
@@ -4,14 +4,14 @@ install_package() {
 
   # Only perform it if package is not installed so we don't run it twice on fresh install
   # and on upgrade
-  ${PIP} list installed | grep st2-enterprise-rbac-backend > /dev/null
+  ${PIP} list installed | grep st2-rbac-backend > /dev/null
   PIP_EXIT_CODE=$?
   which /opt/stackstorm/st2/bin/st2-apply-rbac-definitions > /dev/null 2>&1
   WHICH_EXIT_CODE=$?
 
   if [ ${PIP_EXIT_CODE} -eq 1 ] || [ ${WHICH_EXIT_CODE} -eq 1 ]; then
       # NOTE: We ignore errors (e.g. on uninstall when package doesn't exist on disk anymore)
-      ${PIP} install --find-links ${WHEELSDIR} --no-index --quiet --upgrade --force-reinstall st2-enterprise-rbac-backend || :
+      ${PIP} install --find-links ${WHEELSDIR} --no-index --quiet --upgrade --force-reinstall st2-rbac-backend || :
   fi
 }
 

--- a/rpm/postun_script.spec
+++ b/rpm/postun_script.spec
@@ -1,6 +1,6 @@
 uninstall_package() {
   PIP=/opt/stackstorm/st2/bin/pip
-  ${PIP} uninstall -y --quiet st2-enterprise-rbac-backend 1>/dev/null || :
+  ${PIP} uninstall -y --quiet st2-rbac-backend 1>/dev/null || :
 }
 
 disable_rbac() {

--- a/rpm/st2-rbac-backend.spec
+++ b/rpm/st2-rbac-backend.spec
@@ -21,7 +21,7 @@ Release:        %{release}
 License:        Apache 2.0
 Summary:        RBAC Backend for StackStorm
 URL:            https://stackstorm.com
-Source0:        st2-enterprise-rbac-backend
+Source0:        st2-rbac-backend
 
 Requires: crudini st2
 

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     test_suite='tests',
     entry_points={
         'st2common.rbac.backend': [
-            'enterprise = st2rbac_backend.backend:EnterpriseRBACBackend',
+            'default = st2rbac_backend.backend:RBACBackend',
         ],
     },
     zip_safe=False

--- a/st2rbac_backend/backend.py
+++ b/st2rbac_backend/backend.py
@@ -20,11 +20,11 @@ from st2rbac_backend.utils import RBACUtils
 from st2rbac_backend.syncer import RBACRemoteGroupToRoleSyncer
 
 __all__ = [
-    'EnterpriseRBACBackend'
+    'RBACBackend'
 ]
 
 
-class EnterpriseRBACBackend(BaseRBACBackend):
+class RBACBackend(BaseRBACBackend):
     def get_resolver_for_resource_type(self, resource_type):
         return resolvers.get_resolver_for_resource_type(resource_type=resource_type)
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -48,7 +48,7 @@ class BaseAPIControllerWithRBACTestCase(BaseFunctionalTest, CleanDbTestCase):
 
         # Make sure RBAC is enabeld
         cfg.CONF.set_override(name='enable', override=True, group='rbac')
-        cfg.CONF.set_override(name='backend', override='enterprise', group='rbac')
+        cfg.CONF.set_override(name='backend', override='default', group='rbac')
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/unit/test_auth_handlers.py
+++ b/tests/unit/test_auth_handlers.py
@@ -40,7 +40,7 @@ class AuthHandlerRBACRoleSyncTestCase(CleanDbTestCase):
         super(AuthHandlerRBACRoleSyncTestCase, self).setUp()
 
         cfg.CONF.set_override(group='auth', name='backend', override='mock')
-        cfg.CONF.set_override(group='rbac', name='backend', override='enterprise')
+        cfg.CONF.set_override(group='rbac', name='backend', override='default')
 
         self.users = {}
         self.roles = {}

--- a/tests/unit/test_rbac.py
+++ b/tests/unit/test_rbac.py
@@ -38,7 +38,7 @@ class RBACUtilsTestCase(CleanDbTestCase):
     def setUpClass(cls):
         super(RBACUtilsTestCase, cls).setUpClass()
         config.parse_args()
-        cfg.CONF.set_override(name='backend', override='enterprise', group='rbac')
+        cfg.CONF.set_override(name='backend', override='default', group='rbac')
 
     def setUp(self):
         super(RBACUtilsTestCase, self).setUp()

--- a/tests/unit/test_rbac_resolvers.py
+++ b/tests/unit/test_rbac_resolvers.py
@@ -34,7 +34,7 @@ from st2common.models.db.pack import PackDB
 from st2common.rbac.migrations import insert_system_roles
 from st2tests.base import CleanDbTestCase
 
-from st2rbac_backend.backend import EnterpriseRBACBackend
+from st2rbac_backend.backend import RBACBackend
 from st2rbac_backend.service import RBACService as rbac_service
 
 __all__ = [
@@ -47,11 +47,11 @@ class BasePermissionsResolverTestCase(CleanDbTestCase):
     def setUp(self):
         super(BasePermissionsResolverTestCase, self).setUp()
 
-        self.backend = EnterpriseRBACBackend()
+        self.backend = RBACBackend()
 
         # Make sure RBAC is enabeld
         cfg.CONF.set_override(name='enable', override=True, group='rbac')
-        cfg.CONF.set_override(name='backend', override='enterprise', group='rbac')
+        cfg.CONF.set_override(name='backend', override='default', group='rbac')
 
         self.users = {}
         self.roles = {}
@@ -284,7 +284,7 @@ class PermissionsResolverUtilsTestCase(unittest2.TestCase):
     def setUp(self):
         super(PermissionsResolverUtilsTestCase, self).setUp()
 
-        self.backend = EnterpriseRBACBackend()
+        self.backend = RBACBackend()
 
     def test_get_resolver_for_resource_type_valid_resource_type(self):
         valid_resources_types = [ResourceType.PACK, ResourceType.SENSOR, ResourceType.ACTION,

--- a/tests/unit/test_rbac_service.py
+++ b/tests/unit/test_rbac_service.py
@@ -42,7 +42,7 @@ class RBACServiceTestCase(CleanDbTestCase):
 
         # Make sure RBAC is enabeld
         cfg.CONF.set_override(name='enable', override=True, group='rbac')
-        cfg.CONF.set_override(name='backend', override='enterprise', group='rbac')
+        cfg.CONF.set_override(name='backend', override='default', group='rbac')
 
         # TODO: Share mocks
 


### PR DESCRIPTION
The package has been renamed and built but then references to enterprise are still everyone in the package code and scripts. This patch cleans up those references.