### PR TITLE
Define ./build as the rpm build directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,4 +321,4 @@ deb:
 	dpkg-buildpackage -b -uc -us -j`_cpunum=$$(nproc); echo "${_cpunum:-1}"`
 
 rpm:
-	rpmbuild -bb rpm/st2-rbac-backend.spec
+	rpmbuild -bb --define '_topdir %(readlink -f build)' rpm/st2-rbac-backend.spec


### PR DESCRIPTION
Define ./build under project root as the rpm build directory otherwise the rpmbuild will use /rpmbuild by default.