### PR TITLE
Fix CI test failure and upgrade pip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,17 +158,17 @@ compilepy3:
 		echo "==========================================================="; \
 		echo "Installing runner:" $$component; \
 		echo "==========================================================="; \
-        (. $(VIRTUALENV_DIR)/bin/activate; cd $$component; python setup.py develop --no-deps); \
+        	(. $(VIRTUALENV_DIR)/bin/activate; cd $$component; python3 setup.py develop --no-deps); \
 	done
 	@echo ""
 	@echo "================== register metrics drivers ======================"
 	@echo ""
 	# Install st2common to register metrics drivers
-	(. $(VIRTUALENV_DIR)/bin/activate; cd $(ST2_REPO_PATH)/st2common; python setup.py develop --no-deps)
+	(. $(VIRTUALENV_DIR)/bin/activate; cd $(ST2_REPO_PATH)/st2common; python3 setup.py develop --no-deps)
 	@echo ""
 	@echo "================== register rbac backend ======================"
 	@echo ""
-	(. $(VIRTUALENV_DIR)/bin/activate; python setup.py develop --no-deps)
+	(. $(VIRTUALENV_DIR)/bin/activate; python3 setup.py develop --no-deps)
 
 # NOTE: We pass --no-deps to the script so we don't install all the
 # package dependencies which are already installed as part of "requirements"
@@ -180,6 +180,8 @@ requirements: .clone_st2_repo virtualenv
 	@echo
 	#. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache $(PIP_OPTIONS) -r /tmp/st2/requirements.txt
 	#. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache $(PIP_OPTIONS) -r /tmp/st2/test-requirements.txt
+	$(eval PIP_VERSION := $(shell grep 'PIP_VERSION ?= ' /tmp/st2/Makefile | awk '{ print $$3}'))
+	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pip==$(PIP_VERSION)"
 	$(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache $(PIP_OPTIONS) -r $(ST2_REPO_PATH)/requirements.txt
 	$(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache $(PIP_OPTIONS) -r $(ST2_REPO_PATH)/test-requirements.txt
 	$(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache $(PIP_OPTIONS) -r requirements.txt
@@ -191,17 +193,17 @@ requirements: .clone_st2_repo virtualenv
         echo "==========================================================="; \
         echo "Installing runner:" $$component; \
         echo "==========================================================="; \
-        (. $(VIRTUALENV_DIR)/bin/activate; cd $$component; python setup.py develop --no-deps); \
+        (. $(VIRTUALENV_DIR)/bin/activate; cd $$component; python3 setup.py develop); \
 	done
 	@echo ""
 	@echo "================== register metrics drivers ======================"
 	@echo ""
 	# Install st2common to register metrics drivers
-	(. $(VIRTUALENV_DIR)/bin/activate; cd $(ST2_REPO_PATH)/st2common; python setup.py develop --no-deps)
+	(. $(VIRTUALENV_DIR)/bin/activate; cd $(ST2_REPO_PATH)/st2common; python3 setup.py develop --no-deps)
 	@echo ""
 	@echo "================== register rbac backend ======================"
 	@echo ""
-	(. $(VIRTUALENV_DIR)/bin/activate; python setup.py develop --no-deps)
+	(. $(VIRTUALENV_DIR)/bin/activate; python3 setup.py develop --no-deps)
 
 .PHONY: requirements-ci
 requirements-ci:
@@ -221,7 +223,7 @@ $(VIRTUALENV_DIR)/bin/activate:
 	@echo
 	@echo "==================== virtualenv ===================="
 	@echo
-	test -d $(VIRTUALENV_DIR) || virtualenv $(VIRTUALENV_DIR)
+	test -d $(VIRTUALENV_DIR) || virtualenv $(VIRTUALENV_DIR) -p python3
 
 	# Setup PYTHONPATH in bash activate script...
 	# Delete existing entries (if any)

--- a/tests/unit/controllers/api/v1/test_alias_execution_rbac.py
+++ b/tests/unit/controllers/api/v1/test_alias_execution_rbac.py
@@ -37,7 +37,7 @@ TEST_LOAD_MODELS = {
 
 EXECUTION = ActionExecutionDB(id='54e657d60640fd16887d6855',
                               status=LIVEACTION_STATUS_SUCCEEDED,
-                              result='')
+                              result={})
 
 __all__ = [
     'AliasExecutionWithRBACTestCase'

--- a/tests/unit/controllers/api/v1/test_alias_execution_rbac.py
+++ b/tests/unit/controllers/api/v1/test_alias_execution_rbac.py
@@ -16,6 +16,7 @@
 import mock
 
 from st2common.constants.action import LIVEACTION_STATUS_SUCCEEDED
+from st2common.bootstrap import runnersregistrar as runners_registrar
 from st2common.models.db.execution import ActionExecutionDB
 from st2common.services import action as action_service
 from st2tests.fixturesloader import FixturesLoader
@@ -52,6 +53,7 @@ class AliasExecutionWithRBACTestCase(APIControllerWithRBACTestCase):
                                                            fixtures_dict=TEST_MODELS)
         self.alias1 = self.models['aliases']['alias1.yaml']
         self.alias2 = self.models['aliases']['alias2.yaml']
+        runners_registrar.register_runners()
 
     @mock.patch.object(action_service, 'request',
                        return_value=(None, EXECUTION))


### PR DESCRIPTION
As part of the ST2 change under commit https://github.com/StackStorm/st2/commit/1ad0063f8fff43f4357ebb260d94b5c4950a915a, the example alias1 was changed to use the noop runner.
The RBAC CI test was failing, as it didn't find the runner, as it was missing the step to register runners.

Update the RBAC CI test and also update to use the pip version from st2 Makefile.