### PR TITLE
Added RBAC unit tests for clone action API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ ROOT_DIR ?= $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 CURRENT_DIR ?= $(shell pwd)
 VIRTUALENV_DIR ?= virtualenv
 ST2_REPO_PATH ?= /tmp/st2
-ST2_REPO_URL ?= git@github.com:ashwini-orchestral/st2.git
-ST2_REPO_BRANCH ?= clone_action_api
+ST2_REPO_URL ?= git@github.com:StackStorm/st2.git
+ST2_REPO_BRANCH ?= master
 
 # nasty hack to get a space into a variable
 empty:=

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ ROOT_DIR ?= $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 CURRENT_DIR ?= $(shell pwd)
 VIRTUALENV_DIR ?= virtualenv
 ST2_REPO_PATH ?= /tmp/st2
-ST2_REPO_URL ?= git@github.com:StackStorm/st2.git
-ST2_REPO_BRANCH ?= master
+ST2_REPO_URL ?= git@github.com:ashwini-orchestral/st2.git
+ST2_REPO_BRANCH ?= clone_action_api
 
 # nasty hack to get a space into a variable
 empty:=

--- a/st2rbac_backend/__init__.py
+++ b/st2rbac_backend/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '3.7dev'
+__version__ = "3.7dev"

--- a/tests/unit/controllers/api/v1/test_actions_rbac.py
+++ b/tests/unit/controllers/api/v1/test_actions_rbac.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import mock
+import os
 import six
 
 import st2common.validators.api.action as action_validator
@@ -56,6 +57,19 @@ ACTION_2 = {
         'c': {'type': 'string', 'default': 'C1', 'position': 0},
         'd': {'type': 'string', 'default': 'D1', 'immutable': True}
     }
+}
+
+ACTION_3 = {
+    "name": "ma.dummy.clone_action",
+    "pack": "clonepack",
+    "description": "test description",
+    "enabled": True,
+    "entry_point": "/tmp/test/clone_action.sh",
+    "runner_type": "local-shell-script",
+    "parameters": {
+        "x": {"type": "string", "default": "A1"},
+        "y": {"type": "string", "default": "B1"},
+    },
 }
 
 
@@ -106,6 +120,101 @@ class ActionControllerRBACTestCase(APIControllerWithRBACTestCase,
             user=user_db.name,
             role=self.roles['action_create'].name,
             source='assignments/%s.yaml' % user_db.name)
+        UserRoleAssignment.add_or_update(role_assignment_db)
+
+        # creating `action_clone` user with all permissions related to cloning an action
+        user_3_db = UserDB(name="action_clone")
+        user_3_db = User.add_or_update(user_3_db)
+        self.users["action_clone"] = user_3_db
+
+        # roles of action_clone user
+        grant_db = PermissionGrantDB(resource_uid="pack:clonepack",
+                                     resource_type=ResourceType.PACK,
+                                     permission_types=[PermissionType.ACTION_CREATE])
+        grant_db = PermissionGrant.add_or_update(grant_db)
+        grant_db_view = PermissionGrantDB(resource_uid="pack:examples",
+                                          resource_type=ResourceType.PACK,
+                                          permission_types=[PermissionType.ACTION_VIEW])
+        grant_db_view = PermissionGrant.add_or_update(grant_db_view)
+        grant_db_create = PermissionGrantDB(resource_uid="pack:examples",
+                                            resource_type=ResourceType.PACK,
+                                            permission_types=[PermissionType.ACTION_CREATE])
+        grant_db_create = PermissionGrant.add_or_update(grant_db_create)
+        grant_db_delete = PermissionGrantDB(resource_uid="pack:clonepack",
+                                            resource_type=ResourceType.PACK,
+                                            permission_types=[PermissionType.ACTION_DELETE])
+        grant_db_delete = PermissionGrant.add_or_update(grant_db_delete)
+        permission_grants = [
+            str(grant_db.id),
+            str(grant_db_view.id),
+            str(grant_db_create.id),
+            str(grant_db_delete.id),
+        ]
+        role_1_db = RoleDB(name="action_clone", permission_grants=permission_grants)
+        role_1_db = Role.add_or_update(role_1_db)
+        self.roles["action_clone"] = role_1_db
+
+        # role assignments for action_clone user
+        user_db = self.users["action_clone"]
+        role_assignment_db = UserRoleAssignmentDB(user=user_db.name,
+                                                  role=self.roles["action_clone"].name,
+                                                  source="assignments/%s.yaml" % user_db.name)
+        UserRoleAssignment.add_or_update(role_assignment_db)
+
+        # creating `no_create_permission` user with action_view permission on source action
+        # but no create_action permission on destination pack
+        user_2_db = UserDB(name="no_create_permission")
+        user_2_db = User.add_or_update(user_2_db)
+        self.users["no_create_permission"] = user_2_db
+
+        # roles of no_create_permission user
+        grant_db = PermissionGrantDB(resource_uid="pack:examples",
+                                     resource_type=ResourceType.PACK,
+                                     permission_types=[PermissionType.ACTION_VIEW])
+        grant_db = PermissionGrant.add_or_update(grant_db)
+        grant_db_delete = PermissionGrantDB(resource_uid="pack:clonepack",
+                                            resource_type=ResourceType.PACK,
+                                            permission_types=[PermissionType.ACTION_DELETE])
+        grant_db_delete = PermissionGrant.add_or_update(grant_db_delete)
+        permission_grants = [str(grant_db.id), str(grant_db_delete.id)]
+        role_1_db = RoleDB(name="no_create_permission",
+                           permission_grants=permission_grants)
+        role_1_db = Role.add_or_update(role_1_db)
+        self.roles["no_create_permission"] = role_1_db
+
+        # role assignments for no_create_permission user
+        user_db = self.users["no_create_permission"]
+        role_assignment_db = UserRoleAssignmentDB(user=user_db.name,
+                                                  role=self.roles["no_create_permission"].name,
+                                                  source="assignments/%s.yaml" % user_db.name)
+        UserRoleAssignment.add_or_update(role_assignment_db)
+
+        # creating `no_delete_permission` user with action_view permission on source action,
+        # action_create on destination pack but no create_delete permission on destination pack
+        user_2_db = UserDB(name="no_delete_permission")
+        user_2_db = User.add_or_update(user_2_db)
+        self.users["no_delete_permission"] = user_2_db
+
+        # roles of no_delete_permission user
+        grant_db_view = PermissionGrantDB(resource_uid="pack:examples",
+                                          resource_type=ResourceType.PACK,
+                                          permission_types=[PermissionType.ACTION_VIEW])
+        grant_db_view = PermissionGrant.add_or_update(grant_db_view)
+        grant_db_create = PermissionGrantDB(resource_uid="pack:clonepack",
+                                            resource_type=ResourceType.PACK,
+                                            permission_types=[PermissionType.ACTION_CREATE])
+        grant_db_create = PermissionGrant.add_or_update(grant_db_create)
+        permission_grants = [str(grant_db_view.id), str(grant_db_create.id)]
+        role_1_db = RoleDB(name="no_delete_permission",
+                           permission_grants=permission_grants)
+        role_1_db = Role.add_or_update(role_1_db)
+        self.roles["no_delete_permission"] = role_1_db
+
+        # role assignments for no_delete_permission user
+        user_db = self.users["no_delete_permission"]
+        role_assignment_db = UserRoleAssignmentDB(user=user_db.name,
+                                                  role=self.roles["no_delete_permission"].name,
+                                                  source="assignments/%s.yaml" % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
     def test_create_action_no_action_create_permission(self):
@@ -165,6 +274,146 @@ class ActionControllerRBACTestCase(APIControllerWithRBACTestCase,
         resp = self.app.get('/v1/actions?limit=20000')
         self.assertEqual(resp.status_code, http_client.OK)
 
+    @mock.patch.object(os.path, "isdir", mock.MagicMock(return_value=True))
+    @mock.patch("st2api.controllers.v1.actions.clone_action_files")
+    @mock.patch.object(action_validator,
+                       "validate_action",
+                       mock.MagicMock(return_value=True))
+    def test_clone_action_success(self, mock_clone_action):
+        user_db = self.users["action_clone"]
+        self.use_user(user_db)
+        self.__do_post(ACTION_2)
+        self.__do_post(ACTION_3)
+        dest_data_body = {
+            "dest_pack": ACTION_3["pack"],
+            "dest_action": "clone_action_2",
+        }
+        source_ref_or_id = "%s.%s" % (ACTION_2["pack"], ACTION_2["name"])
+        clone_resp = self.__do_clone(dest_data_body, source_ref_or_id)
+        self.assertEqual(clone_resp.status_code, http_client.CREATED)
+
+    @mock.patch.object(os.path, "isdir", mock.MagicMock(return_value=True))
+    @mock.patch("st2api.controllers.v1.actions.remove_temp_action_files")
+    @mock.patch("st2api.controllers.v1.actions.restore_temp_action_files")
+    @mock.patch("st2api.controllers.v1.actions.temp_backup_action_files")
+    @mock.patch("st2api.controllers.v1.actions.clone_action_files")
+    @mock.patch.object(action_validator,
+                       "validate_action",
+                       mock.MagicMock(return_value=True))
+    def test_clone_overwrite_action_success(self,
+                                            mock_clone_action,
+                                            mock_backup_files,
+                                            mock_restore_files,
+                                            mock_remove_backup):
+        user_db = self.users["action_clone"]
+        self.use_user(user_db)
+        self.__do_post(ACTION_2)
+        self.__do_post(ACTION_3)
+        dest_data_body = {
+            "dest_pack": ACTION_3["pack"],
+            "dest_action": ACTION_3["name"],
+            "overwrite": True,
+        }
+        source_ref_or_id = "%s.%s" % (ACTION_2["pack"], ACTION_2["name"])
+        clone_resp = self.__do_clone(dest_data_body, source_ref_or_id)
+        self.assertEqual(clone_resp.status_code, http_client.CREATED)
+
+    @mock.patch.object(action_validator,
+                       "validate_action",
+                       mock.MagicMock(return_value=True))
+    def test_clone_action_no_source_action_view_permission(self):
+        user_db = self.users["action_create"]
+        self.use_user(user_db)
+        self.__do_post(ACTION_2)
+        user_db = self.users["no_permissions"]
+        self.use_user(user_db)
+        dest_data_body = {
+            "dest_pack": ACTION_3["pack"],
+            "dest_action": "clone_action_3",
+        }
+        source_ref_or_id = "%s.%s" % (ACTION_2["pack"], ACTION_2["name"])
+        clone_resp = self.__do_clone(dest_data_body,
+                                     source_ref_or_id,
+                                     expect_errors=True)
+        expected_msg = ('User "no_permissions" doesn\'t have required permission '
+                        '"action_view" on resource "action:examples:ma.dummy.action"')
+        self.assertEqual(clone_resp.status_code, http_client.UNAUTHORIZED)
+        self.assertEqual(clone_resp.json["faultstring"], expected_msg)
+
+    @mock.patch.object(os.path, "isdir", mock.MagicMock(return_value=True))
+    @mock.patch.object(action_validator,
+                       "validate_action",
+                       mock.MagicMock(return_value=True))
+    def test_clone_action_no_destination_action_create_permission(self):
+        user_db = self.users["action_clone"]
+        self.use_user(user_db)
+        self.__do_post(ACTION_2)
+        self.__do_post(ACTION_3)
+        user_db = self.users["no_create_permission"]
+        self.use_user(user_db)
+        dest_data_body = {
+            "dest_pack": ACTION_3["pack"],
+            "dest_action": "clone_action_4",
+        }
+        source_ref_or_id = "%s.%s" % (ACTION_2["pack"], ACTION_2["name"])
+        clone_resp = self.__do_clone(dest_data_body,
+                                     source_ref_or_id,
+                                     expect_errors=True)
+        expected_msg = ('User "no_create_permission" doesn\'t have required permission '
+                        '"action_create" on resource "action:clonepack:clone_action_4"')
+        self.assertEqual(clone_resp.status_code, http_client.UNAUTHORIZED)
+        self.assertEqual(clone_resp.json["faultstring"], expected_msg)
+
+    @mock.patch.object(os.path, "isdir", mock.MagicMock(return_value=True))
+    @mock.patch.object(action_validator,
+                       "validate_action",
+                       mock.MagicMock(return_value=True))
+    def test_clone_overwrite_no_destination_action_create_permission(self):
+        user_db = self.users["action_clone"]
+        self.use_user(user_db)
+        self.__do_post(ACTION_2)
+        self.__do_post(ACTION_3)
+        user_db = self.users["no_create_permission"]
+        self.use_user(user_db)
+        dest_data_body = {
+            "dest_pack": ACTION_3["pack"],
+            "dest_action": ACTION_3["name"],
+            "overwrite": True,
+        }
+        source_ref_or_id = "%s.%s" % (ACTION_2["pack"], ACTION_2["name"])
+        clone_resp = self.__do_clone(dest_data_body,
+                                     source_ref_or_id,
+                                     expect_errors=True)
+        expected_msg = ('User "no_create_permission" doesn\'t have required permission '
+                        '"action_create" on resource "action:clonepack:ma.dummy.clone_action"')
+        self.assertEqual(clone_resp.status_code, http_client.UNAUTHORIZED)
+        self.assertEqual(clone_resp.json["faultstring"], expected_msg)
+
+    @mock.patch.object(os.path, "isdir", mock.MagicMock(return_value=True))
+    @mock.patch.object(action_validator,
+                       "validate_action",
+                       mock.MagicMock(return_value=True))
+    def test_clone_overwrite_no_destination_action_delete_permission(self):
+        user_db = self.users["action_clone"]
+        self.use_user(user_db)
+        self.__do_post(ACTION_2)
+        self.__do_post(ACTION_3)
+        user_db = self.users["no_delete_permission"]
+        self.use_user(user_db)
+        dest_data_body = {
+            "dest_pack": ACTION_3["pack"],
+            "dest_action": ACTION_3["name"],
+            "overwrite": True,
+        }
+        source_ref_or_id = "%s.%s" % (ACTION_2["pack"], ACTION_2["name"])
+        clone_resp = self.__do_clone(dest_data_body,
+                                     source_ref_or_id,
+                                     expect_errors=True)
+        expected_msg = ('User "no_delete_permission" doesn\'t have required permission '
+                        '"action_delete" on resource "action:clonepack:ma.dummy.clone_action"')
+        self.assertEqual(clone_resp.status_code, http_client.UNAUTHORIZED)
+        self.assertEqual(clone_resp.json["faultstring"], expected_msg)
+
     def _insert_mock_models(self):
         action_ids = [action['id'] for action in self.models['actions'].values()]
         return action_ids
@@ -178,3 +427,8 @@ class ActionControllerRBACTestCase(APIControllerWithRBACTestCase,
 
     def __do_delete(self, action_id, expect_errors=False):
         return self.app.delete('/v1/actions/%s' % action_id, expect_errors=expect_errors)
+
+    def __do_clone(self, dest_data, action_id, expect_errors=False):
+        return self.app.post_json("/v1/actions/%s/clone" % (action_id),
+                                  dest_data,
+                                  expect_errors=expect_errors)

--- a/tests/unit/controllers/api/v1/test_actions_rbac.py
+++ b/tests/unit/controllers/api/v1/test_actions_rbac.py
@@ -360,7 +360,7 @@ class ActionControllerRBACTestCase(APIControllerWithRBACTestCase,
         source_ref_or_id = "%s.%s" % (ACTION_2["pack"], ACTION_2["name"])
         clone_resp = self.__do_clone(dest_data_body,
                                      source_ref_or_id,
-                                     expect_errors=True)        
+                                     expect_errors=True)
         expected_msg = ('User "%s" doesn\'t have required permission '
                         '"action_create" on resource "action:%s:%s"'
                         % (user_db.name, ACTION_3["pack"], dest_data_body["dest_action"]))

--- a/tests/unit/controllers/api/v1/test_actions_rbac.py
+++ b/tests/unit/controllers/api/v1/test_actions_rbac.py
@@ -97,7 +97,6 @@ class ActionControllerRBACTestCase(APIControllerWithRBACTestCase,
             fixtures_dict={'actions': [file_name]})['actions'][file_name]
 
         # Insert mock users, roles and assignments
-
         # Users
         user_2_db = UserDB(name='action_create')
         user_2_db = User.add_or_update(user_2_db)
@@ -283,7 +282,6 @@ class ActionControllerRBACTestCase(APIControllerWithRBACTestCase,
         user_db = self.users["action_clone"]
         self.use_user(user_db)
         self.__do_post(ACTION_2)
-        self.__do_post(ACTION_3)
         dest_data_body = {
             "dest_pack": ACTION_3["pack"],
             "dest_action": "clone_action_2",
@@ -324,7 +322,7 @@ class ActionControllerRBACTestCase(APIControllerWithRBACTestCase,
     def test_clone_action_no_source_action_view_permission(self):
         user_db = self.users["action_create"]
         self.use_user(user_db)
-        self.__do_post(ACTION_2)
+        post_resp = self.__do_post(ACTION_2)
         user_db = self.users["no_permissions"]
         self.use_user(user_db)
         dest_data_body = {
@@ -336,7 +334,7 @@ class ActionControllerRBACTestCase(APIControllerWithRBACTestCase,
                                      source_ref_or_id,
                                      expect_errors=True)
         expected_msg = ('User "no_permissions" doesn\'t have required permission '
-                        '"action_view" on resource "action:examples:ma.dummy.action"')
+                        '"action_view" on resource "%s"' % (post_resp.json["uid"]))
         self.assertEqual(clone_resp.status_code, http_client.UNAUTHORIZED)
         self.assertEqual(clone_resp.json["faultstring"], expected_msg)
 
@@ -348,7 +346,6 @@ class ActionControllerRBACTestCase(APIControllerWithRBACTestCase,
         user_db = self.users["action_clone"]
         self.use_user(user_db)
         self.__do_post(ACTION_2)
-        self.__do_post(ACTION_3)
         user_db = self.users["no_create_permission"]
         self.use_user(user_db)
         dest_data_body = {
@@ -359,8 +356,9 @@ class ActionControllerRBACTestCase(APIControllerWithRBACTestCase,
         clone_resp = self.__do_clone(dest_data_body,
                                      source_ref_or_id,
                                      expect_errors=True)
-        expected_msg = ('User "no_create_permission" doesn\'t have required permission '
-                        '"action_create" on resource "action:clonepack:clone_action_4"')
+        expected_msg = ('User "no_create_permission" doesn\'t have required '
+                        'permission "action_create" on resource "action:%s:%s"'
+                        % (ACTION_3["pack"], dest_data_body["dest_action"]))
         self.assertEqual(clone_resp.status_code, http_client.UNAUTHORIZED)
         self.assertEqual(clone_resp.json["faultstring"], expected_msg)
 
@@ -384,8 +382,9 @@ class ActionControllerRBACTestCase(APIControllerWithRBACTestCase,
         clone_resp = self.__do_clone(dest_data_body,
                                      source_ref_or_id,
                                      expect_errors=True)
-        expected_msg = ('User "no_create_permission" doesn\'t have required permission '
-                        '"action_create" on resource "action:clonepack:ma.dummy.clone_action"')
+        expected_msg = ('User "no_create_permission" doesn\'t have required '
+                        'permission "action_create" on resource "action:%s:%s"'
+                        % (ACTION_3["pack"], ACTION_3["name"]))
         self.assertEqual(clone_resp.status_code, http_client.UNAUTHORIZED)
         self.assertEqual(clone_resp.json["faultstring"], expected_msg)
 
@@ -409,8 +408,9 @@ class ActionControllerRBACTestCase(APIControllerWithRBACTestCase,
         clone_resp = self.__do_clone(dest_data_body,
                                      source_ref_or_id,
                                      expect_errors=True)
-        expected_msg = ('User "no_delete_permission" doesn\'t have required permission '
-                        '"action_delete" on resource "action:clonepack:ma.dummy.clone_action"')
+        expected_msg = ('User "no_delete_permission" doesn\'t have required '
+                        'permission "action_delete" on resource "action:%s:%s"'
+                        % (ACTION_3["pack"], ACTION_3["name"]))
         self.assertEqual(clone_resp.status_code, http_client.UNAUTHORIZED)
         self.assertEqual(clone_resp.json["faultstring"], expected_msg)
 

--- a/tests/unit/controllers/api/v1/test_actions_rbac.py
+++ b/tests/unit/controllers/api/v1/test_actions_rbac.py
@@ -52,7 +52,7 @@ ACTION_2 = {
     'description': 'test description',
     'enabled': True,
     'entry_point': '/tmp/test/action2.py',
-    'runner_type': 'local-shell-script',
+    'runner_type': 'python-script',
     'parameters': {
         'c': {'type': 'string', 'default': 'C1', 'position': 0},
         'd': {'type': 'string', 'default': 'D1', 'immutable': True}
@@ -315,6 +315,11 @@ class ActionControllerRBACTestCase(APIControllerWithRBACTestCase,
         source_ref_or_id = "%s.%s" % (ACTION_2["pack"], ACTION_2["name"])
         clone_resp = self.__do_clone(dest_data_body, source_ref_or_id)
         self.assertEqual(clone_resp.status_code, http_client.CREATED)
+        expected_params_dict = ACTION_2["parameters"]
+        actual_prams_dict = clone_resp.json["parameters"]
+        self.assertDictEqual(actual_prams_dict, expected_params_dict)
+        actual_runner_type = clone_resp.json["runner_type"]
+        self.assertNotEqual(actual_runner_type, ACTION_3["runner_type"])
 
     @mock.patch.object(action_validator,
                        "validate_action",
@@ -333,8 +338,8 @@ class ActionControllerRBACTestCase(APIControllerWithRBACTestCase,
         clone_resp = self.__do_clone(dest_data_body,
                                      source_ref_or_id,
                                      expect_errors=True)
-        expected_msg = ('User "no_permissions" doesn\'t have required permission '
-                        '"action_view" on resource "%s"' % (post_resp.json["uid"]))
+        expected_msg = ('User "%s" doesn\'t have required permission "action_view" '
+                        'on resource "%s"' % (user_db.name, post_resp.json["uid"]))
         self.assertEqual(clone_resp.status_code, http_client.UNAUTHORIZED)
         self.assertEqual(clone_resp.json["faultstring"], expected_msg)
 
@@ -355,10 +360,10 @@ class ActionControllerRBACTestCase(APIControllerWithRBACTestCase,
         source_ref_or_id = "%s.%s" % (ACTION_2["pack"], ACTION_2["name"])
         clone_resp = self.__do_clone(dest_data_body,
                                      source_ref_or_id,
-                                     expect_errors=True)
-        expected_msg = ('User "no_create_permission" doesn\'t have required '
-                        'permission "action_create" on resource "action:%s:%s"'
-                        % (ACTION_3["pack"], dest_data_body["dest_action"]))
+                                     expect_errors=True)        
+        expected_msg = ('User "%s" doesn\'t have required permission '
+                        '"action_create" on resource "action:%s:%s"'
+                        % (user_db.name, ACTION_3["pack"], dest_data_body["dest_action"]))
         self.assertEqual(clone_resp.status_code, http_client.UNAUTHORIZED)
         self.assertEqual(clone_resp.json["faultstring"], expected_msg)
 
@@ -382,9 +387,9 @@ class ActionControllerRBACTestCase(APIControllerWithRBACTestCase,
         clone_resp = self.__do_clone(dest_data_body,
                                      source_ref_or_id,
                                      expect_errors=True)
-        expected_msg = ('User "no_create_permission" doesn\'t have required '
-                        'permission "action_create" on resource "action:%s:%s"'
-                        % (ACTION_3["pack"], ACTION_3["name"]))
+        expected_msg = ('User "%s" doesn\'t have required permission '
+                        '"action_create" on resource "action:%s:%s"'
+                        % (user_db.name, ACTION_3["pack"], ACTION_3["name"]))
         self.assertEqual(clone_resp.status_code, http_client.UNAUTHORIZED)
         self.assertEqual(clone_resp.json["faultstring"], expected_msg)
 
@@ -408,9 +413,9 @@ class ActionControllerRBACTestCase(APIControllerWithRBACTestCase,
         clone_resp = self.__do_clone(dest_data_body,
                                      source_ref_or_id,
                                      expect_errors=True)
-        expected_msg = ('User "no_delete_permission" doesn\'t have required '
-                        'permission "action_delete" on resource "action:%s:%s"'
-                        % (ACTION_3["pack"], ACTION_3["name"]))
+        expected_msg = ('User "%s" doesn\'t have required permission '
+                        '"action_delete" on resource "action:%s:%s"'
+                        % (user_db.name, ACTION_3["pack"], ACTION_3["name"]))
         self.assertEqual(clone_resp.status_code, http_client.UNAUTHORIZED)
         self.assertEqual(clone_resp.json["faultstring"], expected_msg)
 


### PR DESCRIPTION
For action clone API, RBAC unit tests for following scenarios are added:
* ACTION_VIEW permission on source action
* ACTION_CREATE permission on destination action if destination action doesn't exist
* ACTION_CREATE permission on destination action if destination action exists
* ACTION_DELETE permission on destination action in case of action clone overwrite