### PR TITLE
Clean up setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,8 @@ import os
 
 from setuptools import setup, find_packages
 
-from dist_utils import check_pip_version
 from dist_utils import fetch_requirements
 from dist_utils import parse_version_string
-
-check_pip_version()
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, "requirements.txt")
@@ -42,13 +39,10 @@ setup(
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Environment :: Console",
     ],
     platforms=["Any"],


### PR DESCRIPTION
Drop problematic pip version check that can break pants/pex lockfile generation. Also, update python classifiers to 3.6-3.8.