### PR TITLE
delete pointless requirements parsing code in dist_utils.py

### DIFF
--- a/.github/workflows/lint-and-unit-tests.yml
+++ b/.github/workflows/lint-and-unit-tests.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build-and-test-python:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # NOTE: Lifted from https://github.com/StackStorm/st2/blob/master/.github/workflows/ci.yaml#L183
     services:
       mongo:

--- a/dist_utils.py
+++ b/dist_utils.py
@@ -21,64 +21,11 @@ import sys
 
 from distutils.version import StrictVersion
 
-GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
-
-try:
-    import pip
-    from pip import __version__ as pip_version
-except ImportError as e:
-    print('Failed to import pip: %s' % (str(e)))
-    print('')
-    print('Download pip:\n%s' % (GET_PIP))
-    sys.exit(1)
-
-try:
-    # pip < 10.0
-    from pip.req import parse_requirements
-except ImportError:
-    # pip >= 10.0
-
-    try:
-        from pip._internal.req.req_file import parse_requirements
-    except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (str(e)))
-        print('Using pip: %s' % (str(pip_version)))
-        sys.exit(1)
-
 __all__ = [
-    'check_pip_version',
-    'fetch_requirements',
     'apply_vagrant_workaround',
     'get_version_string',
     'parse_version_string'
 ]
-
-
-def check_pip_version(min_version='6.0.0'):
-    """
-    Ensure that a minimum supported version of pip is installed.
-    """
-    if StrictVersion(pip.__version__) < StrictVersion(min_version):
-        print("Upgrade pip, your version '{0}' "
-              "is outdated. Minimum required version is '{1}':\n{2}".format(pip.__version__,
-                                                                            min_version,
-                                                                            GET_PIP))
-        sys.exit(1)
-
-
-def fetch_requirements(requirements_file_path):
-    """
-    Return a list of requirements and links by parsing the provided requirements file.
-    """
-    links = []
-    reqs = []
-    for req in parse_requirements(requirements_file_path, session=False):
-        # Note: req.url was used before 9.0.0 and req.link is used in all the recent versions
-        link = getattr(req, 'link', getattr(req, 'url', None))
-        if link:
-            links.append(str(link))
-        reqs.append(str(req.req))
-    return (reqs, links)
 
 
 def apply_vagrant_workaround():

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ import os
 
 from setuptools import setup, find_packages
 
-from dist_utils import fetch_requirements
 from dist_utils import parse_version_string
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -25,7 +24,6 @@ REQUIREMENTS_FILE = os.path.join(BASE_DIR, "requirements.txt")
 INIT_FILE = os.path.join(BASE_DIR, "st2rbac_backend", "__init__.py")
 
 version = parse_version_string(INIT_FILE)
-install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 
 setup(
     name="st2-rbac-backend",
@@ -50,8 +48,8 @@ setup(
     provides=["st2rbac_backend"],
     packages=find_packages(),
     include_package_data=True,
-    install_requires=install_reqs,
-    dependency_links=dep_links,
+    install_requires=[],
+    dependency_links=[],
     test_suite="tests",
     entry_points={
         "st2common.rbac.backend": [


### PR DESCRIPTION
All the magic around parsing requirements was entirely unnecessary for this repo as there are NO reqs.

And please! Doing things on import (like raising an error if pip isn't installed) is not ok.
Do not have side effects on import, even (and especially) in setup code.

This fix is a follow-up for #70, and is blocking https://github.com/StackStorm/st2/pull/5932 because importing pip breaks generating the lockfile in the latest version of pants (which uses pex, which has a vendored copy of pip).